### PR TITLE
Rename Gateway ID to Gateway EUI

### DIFF
--- a/src/_wwwServer.ino
+++ b/src/_wwwServer.ino
@@ -1307,7 +1307,7 @@ static void systemStatus()
 		response +="<th colspan=\"2\" class=\"thead width:120px;\">Set</th>";
 		response +="</tr>";
 	
-		response +="<tr><td style=\"border: 1px solid black;\">Gateway ID</td>";
+		response +="<tr><td style=\"border: 1px solid black;\">Gateway EUI</td>";
 		response +="<td class=\"cell\">";	
 		if (MAC_array[0]< 0x10) response +='0'; response +=String(MAC_array[0],HEX);	// The MAC array is always returned in lowercase
 		if (MAC_array[1]< 0x10) response +='0'; response +=String(MAC_array[1],HEX);


### PR DESCRIPTION
The current web interface shows the "Gateway 
Id". When I tried to create the gateway on ttn (v3) there were two fields: Gateway ID and Gateway EUI.

![image](https://user-images.githubusercontent.com/20213986/132816677-3b6c0c0e-b7f5-4874-b2b3-6bc7d790a7d1.png)

The id shown on the webpage needs to be entered as the EUI and it is confusing that its named differently so I want to change that. 